### PR TITLE
Add neon look with animated pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,11 +12,15 @@ export default function About() {
   };
 
   return (
-    <div className="min-h-screen bg-background py-12 px-4 sm:px-6 lg:px-8">
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-purple-900 py-12 px-4 sm:px-6 lg:px-8"
+    >
       <div className="flex justify-end mb-8">
         <Link
           href="/"
-          className="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors duration-200"
+          className="neon-link inline-flex items-center px-4 py-2 rounded-md"
         >
           <span>返回主页</span>
         </Link>
@@ -73,7 +77,7 @@ export default function About() {
               <p className="text-foreground/80 mb-4">
                 如果您觉得这个工具对您有帮助，可以考虑赞助我们，帮助我们持续改进。
               </p>
-              <button className="bg-blue-500 text-white px-6 py-2 rounded-md hover:bg-blue-600 transition-colors">
+              <button className="neon-link px-6 py-2 rounded-md">
                 成为赞助者
               </button>
             </div>
@@ -123,6 +127,6 @@ export default function About() {
           </div>
         </motion.section>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,9 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --neon-pink: #ff00cc;
+  --neon-blue: #00e0ff;
+  --neon-green: #39ff14;
+  --neon-purple: #b026ff;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -17,5 +23,17 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Orbitron', Arial, Helvetica, sans-serif;
+}
+
+.neon-link {
+  border: 2px solid var(--neon-blue);
+  box-shadow: 0 0 8px var(--neon-blue);
+  transition: box-shadow 0.2s, background 0.2s, color 0.2s;
+}
+
+.neon-link:hover {
+  background: var(--neon-blue);
+  color: #000;
+  box-shadow: 0 0 12px var(--neon-blue);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,23 @@
 import Timeline from '@/components/Timeline';
 import { timelineData } from '@/data/timeline-data';
 import Link from 'next/link';
+import { motion } from 'framer-motion';
 
 export default function Home() {
     return (
-        <main className="min-h-screen relative">
-            <Link style={{ zIndex: 10 }}
-                href="/about" 
-                className="absolute top-4 right-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md shadow-sm transition-colors"
+        <motion.main
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="min-h-screen relative bg-gradient-to-br from-black via-gray-900 to-purple-900"
+        >
+            <Link
+                style={{ zIndex: 10 }}
+                href="/about"
+                className="neon-link absolute top-4 right-4 px-4 py-2 rounded-md"
             >
                 关于
             </Link>
             <Timeline data={timelineData} />
-        </main>
+        </motion.main>
     );
 }


### PR DESCRIPTION
## Summary
- add Google Orbitron font and neon color variables
- implement glowing link/button style
- animate page transitions using framer-motion and neon gradient backgrounds

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ce5887c8333be7f4391f3e16b8a